### PR TITLE
Fix: operator parsing bug causing < and > to be misinterpreted

### DIFF
--- a/main.c
+++ b/main.c
@@ -868,7 +868,6 @@ slot_t left_shift_slots(slot_t a, slot_t b) {
 
 #define MAX_PRECEDENCE 5
 
-#define IS_OPERATOR_CONTINUATION(c) ((c) == '<' || (c) == '>' || (c) == '=')
 
 bin_operator_t bin_operators[] = {
     {.op_string="*", .precedence=4, .compile_op=mul_slots},
@@ -912,9 +911,10 @@ slot_t compile_expression_(char **current, int precedence) {
         // Go over each operator and check if the current operator
         for (size_t i = 0; i < sizeof(bin_operators) / sizeof(bin_operator_t); i++) {
             bin_operator_t *operator = &bin_operators[i];
-            if (operator->op_string[0] != op || (IS_OPERATOR_CONTINUATION(nOP) && operator->op_string[1] != nOP))
+            if (operator->op_string[0] != op)
                 continue;
-
+            if (operator->op_string[1] != 0 && operator->op_string[1] != nOP)
+                continue;
             // Operator found, check precedence.
             if (operator->precedence != precedence)
                 break;


### PR DESCRIPTION
  When testing a Fibonacci sequence program, I discovered inconsistent behavior in while loop conditions:
  - i = 0; while (i < 20) - Does not work (loop never executes)
  - i = 20; while (i > 0) - Works correctly (counts down from 20 to 1)
```
fib(n) {
  if (n <= 1)
    return 1;
  
  return fib(n - 1) + fib(n - 2);
}

main (argc, argv) {
  i = 0;
  while (i < 20) {
    printf("fib %d: %d\n", i, fib(i)); 
    i = i + 1;
  }
}
```


  Issue: The i < 20 comparison operator was being **incorrectly parsed as i << 20** (left bit shift operation).

  from Assembly Output: 
  # disassembled with `disassemble_fragment`
```asm

Disassembly of section .data:

00000000 <.data>:
   0:	48 ff f5             	rex.W push rbp
   3:	48 89 e5             	mov    rbp,rsp
   6:	48 81 ec 60 00 00 00 	sub    rsp,0x60
   d:	48 b8 00 00 00 00 00 	movabs rax,0x0
  14:	00 00 00 
  17:	48 89 85 e8 ff ff ff 	mov    QWORD PTR [rbp-0x18],rax
  1e:	48 8b 85 e8 ff ff ff 	mov    rax,QWORD PTR [rbp-0x18]
  25:	48 89 85 f0 ff ff ff 	mov    QWORD PTR [rbp-0x10],rax
  2c:	48 b8 0a 00 00 00 00 	movabs rax,0xa
  33:	00 00 00 
  36:	48 89 85 e0 ff ff ff 	mov    QWORD PTR [rbp-0x20],rax
  3d:	48 8b 85 f0 ff ff ff 	mov    rax,QWORD PTR [rbp-0x10]
  44:	48 89 85 d8 ff ff ff 	mov    QWORD PTR [rbp-0x28],rax
  4b:	48 8b 8d e0 ff ff ff 	mov    rcx,QWORD PTR [rbp-0x20]
*****************************************************************
  52:	48 d3 a5 d8 ff ff ff 	shl    QWORD PTR [rbp-0x28],cl ; misinterpreted i think..
*****************************************************************
  59:	48 81 bd d8 ff ff ff 	cmp    QWORD PTR [rbp-0x28],0x0
```
### Bug Location: `main.c`: line 915
 
```c
  if (operator->op_string[0] != op || (IS_OPERATOR_CONTINUATION(nOP) && operator->op_string[1] != nOP))
      continue;
```
 ### The Problem:
  - When parsing i < 20: op='<', nOP=' ' (space)
  - For << operator check:
    - operator->op_string[0] != op → '<' != '<' → false
    - IS_OPERATOR_CONTINUATION(' ') → false 
    - (false && operator->op_string[1] != nOP) → false
    - Result: << operator incorrectly matched 
   
### Solution

  Fixed the operator matching logic:
  if (operator->op_string[0] != op)
      continue;
  if (operator->op_string[1] != 0 && operator->op_string[1] != nOP)
      continue;

  Changes:
  1. First character check: operator->op_string[0] != op
  2. Accurate 2-character operator matching:
    - If operator is 2 characters (operator->op_string[1] != 0)
    - Second character must also match exactly (operator->op_string[1] != nOP)



  ### Before Fix:
  - i < 20 → incorrectly parsed as i << 10 → loop terminates immediately
  - i > 0 → incorrectly parsed as bit shift → unexpected behavior

  ### After Fix:
  - i < 20 → correctly generates valid instruction → proper loop execution
  - i > 0 → correctly generates valid instruction → proper loop execution
  - i << 2 → still works correctly as intended bit shift operation

  The fix restores correct operator parsing behavior.